### PR TITLE
行数とページ番号表示位置の調整

### DIFF
--- a/scripts/main.tex
+++ b/scripts/main.tex
@@ -53,7 +53,7 @@
 % 一行あたり文字数の指定
 \mojiparline{35}
 % 1ページあたり行数の指定
-\linesparpage{27}
+\linesparpage{30}
 
 
 % タイトルの出力


### PR DESCRIPTION
タイトルの通り
ページ番号位置はbag fix，行数は27から30行に変更